### PR TITLE
Fixed MacOS issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_CXX_STANDARD 17)
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
 
-find_package(vsg 0.4.1 REQUIRED)
+find_package(vsg 1.0.0 REQUIRED)
 find_package(SDL2 REQUIRED)
 find_package(vsgXchange QUIET)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ project(vsgSDL
 
 set(CMAKE_CXX_STANDARD 17)
 
+option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+
 find_package(vsg 0.4.1 REQUIRED)
 find_package(SDL2 REQUIRED)
 find_package(vsgXchange QUIET)

--- a/include/vsgSDL/export.hpp
+++ b/include/vsgSDL/export.hpp
@@ -1,7 +1,12 @@
+#ifndef VSGSDL_EXPORT_HPP
+#define VSGSDL_EXPORT_HPP
+
 #if defined(vsgSDL_EXPORT)
 #define vsgSDL_LIB __declspec(dllexport)
 #elif defined(vsgSDL_IMPORT)
 #define vsgSDL_LIB __declspec(dllimport)
 #else
 #define vsgSDL_LIB
+#endif
+
 #endif

--- a/include/vsgSDL/export.hpp
+++ b/include/vsgSDL/export.hpp
@@ -1,5 +1,4 @@
-#ifndef VSGSDL_EXPORT_HPP
-#define VSGSDL_EXPORT_HPP
+#pragma once
 
 #if defined(vsgSDL_EXPORT)
 #define vsgSDL_LIB __declspec(dllexport)
@@ -9,4 +8,3 @@
 #define vsgSDL_LIB
 #endif
 
-#endif

--- a/include/vsgSDL/keyboard.hpp
+++ b/include/vsgSDL/keyboard.hpp
@@ -1,5 +1,4 @@
-#ifndef VSGSDL_KEYBOARD_HPP
-#define VSGSDL_KEYBOARD_HPP
+#pragma once
 
 #include <vsg/ui/KeyEvent.h>
 
@@ -22,4 +21,3 @@ namespace vsgSDL {
     };
 }
 
-#endif

--- a/include/vsgSDL/keyboard.hpp
+++ b/include/vsgSDL/keyboard.hpp
@@ -1,3 +1,6 @@
+#ifndef VSGSDL_KEYBOARD_HPP
+#define VSGSDL_KEYBOARD_HPP
+
 #include <vsg/ui/KeyEvent.h>
 
 #include <SDL_keycode.h>
@@ -18,3 +21,5 @@ namespace vsgSDL {
         std::unordered_map<SDL_Keycode, vsg::KeySymbol> keycodeSingular;
     };
 }
+
+#endif

--- a/include/vsgSDL/mouse.hpp
+++ b/include/vsgSDL/mouse.hpp
@@ -1,6 +1,11 @@
+#ifndef VSGSDL_MOUSE_HPP
+#define VSGSDL_MOUSE_HPP
+
 #include <vsg/ui/PointerEvent.h>
 #include <SDL_events.h>
 
 namespace vsgSDL {
     std::pair<vsg::ButtonMask, uint32_t> convertMouseSDL(Uint32, Uint8);
 }
+
+#endif

--- a/include/vsgSDL/mouse.hpp
+++ b/include/vsgSDL/mouse.hpp
@@ -1,5 +1,4 @@
-#ifndef VSGSDL_MOUSE_HPP
-#define VSGSDL_MOUSE_HPP
+#pragma once
 
 #include <vsg/ui/PointerEvent.h>
 #include <SDL_events.h>
@@ -8,4 +7,3 @@ namespace vsgSDL {
     std::pair<vsg::ButtonMask, uint32_t> convertMouseSDL(Uint32, Uint8);
 }
 
-#endif

--- a/include/vsgSDL/version.hpp
+++ b/include/vsgSDL/version.hpp
@@ -1,6 +1,11 @@
+#ifndef VSGSDL_VERSION_HPP
+#define VSGSDL_VERSION_HPP
+
 #include <vsgSDL/export.hpp>
 #include <vsg/core/Version.h>
 
 #define vsgSDL_VERSION_MAJOR    0
 #define vsgSDL_VERSION_MINOR    0
 #define vsgSDL_VERSION_PATCH    1
+
+#endif

--- a/include/vsgSDL/version.hpp
+++ b/include/vsgSDL/version.hpp
@@ -1,5 +1,4 @@
-#ifndef VSGSDL_VERSION_HPP
-#define VSGSDL_VERSION_HPP
+#pragma once
 
 #include <vsgSDL/export.hpp>
 #include <vsg/core/Version.h>
@@ -8,4 +7,3 @@
 #define vsgSDL_VERSION_MINOR    0
 #define vsgSDL_VERSION_PATCH    1
 
-#endif

--- a/include/vsgSDL/window.hpp
+++ b/include/vsgSDL/window.hpp
@@ -1,80 +1,63 @@
 #ifndef VSGSDL_WINDOW_HPP
 #define VSGSDL_WINDOW_HPP
 
-#ifdef WIN32
-#define VK_USE_PLATFORM_WIN32_KHR
-#endif
-
-#ifdef __APPLE__
-#include <TargetConditionals.h>
-#if TARGET_OS_MAC
-#define VK_USE_PLATFORM_MACOS_MVK
-#elif TARGET_OS_IPHONE
-#define VK_USE_PLATFORM_IOS_MVK
-#endif
-#endif
-
+#include <vsgSDL/version.hpp>
 #include <vsgSDL/keyboard.hpp>
 #include <vsgSDL/mouse.hpp>
-#include <vsgSDL/version.hpp>
 
 namespace vsgSDL {
-class vsgSDL_LIB Window {
-public:
-  Window();
-  ~Window();
+    class vsgSDL_LIB Window {
+    public:
+        Window();
+        ~Window();
 
-  std::function<void(const vsg::ref_ptr<vsg::Window>)> focusGained;
-  std::function<void(const vsg::ref_ptr<vsg::Window>)> focusLost;
-  std::function<void(const char[SDL_TEXTINPUTEVENT_TEXT_SIZE])> textInput;
-  std::function<void(const vsg::ref_ptr<vsg::Viewer>)> render;
-  std::function<void(const vsg::ref_ptr<vsg::Window>,
-                     const vsg::ref_ptr<vsg::Viewer>,
-                     const vsg::ref_ptr<vsg::WindowTraits>)>
-      renderInit;
-  std::function<void(const vsg::ref_ptr<vsg::Viewer>)> renderDeinit;
+        std::function<void(const vsg::ref_ptr<vsg::Window>)> focusGained;
+        std::function<void(const vsg::ref_ptr<vsg::Window>)> focusLost;
+        std::function<void(const char[SDL_TEXTINPUTEVENT_TEXT_SIZE])> textInput;
+        std::function<void(const vsg::ref_ptr<vsg::Viewer>)> render;
+        std::function<void(const vsg::ref_ptr<vsg::Window>,
+                           const vsg::ref_ptr<vsg::Viewer>,
+                           const vsg::ref_ptr<vsg::WindowTraits>)> renderInit;
+        std::function<void(const vsg::ref_ptr<vsg::Viewer>)> renderDeinit;
 
-  bool create(std::string title, int x, int y, uint32_t width, uint32_t height,
-              Uint32 sdlWinFlags, bool vulkanDebugLayer,
-              bool vulkanAPIDumpLayer, std::string vulkanDynLib = "");
+        bool create(std::string title, int x, int y, uint32_t width, uint32_t height, Uint32 sdlWinFlags,
+                    bool vulkanDebugLayer, bool vulkanAPIDumpLayer, std::string vulkanDynLib = "");
 
-  bool process(const bool continuousKey);
+        bool process(const bool continuousKey);
+    private:
+        vsg::ref_ptr<vsg::WindowTraits> traits;
+        vsg::ref_ptr<vsg::Instance> instance;
+        vsg::ref_ptr<vsg::Surface> surface;
+        vsg::ref_ptr<vsg::Window> adapter;
+        vsg::ref_ptr<KeyboardMap> keyboardMap;
+        SDL_Window *sdlWindow;
+        vsg::ref_ptr<vsg::Viewer> viewer;
 
-private:
-  vsg::ref_ptr<vsg::WindowTraits> traits;
-  vsg::ref_ptr<vsg::Instance> instance;
-  vsg::ref_ptr<vsg::Surface> surface;
-  vsg::ref_ptr<vsg::Window> adapter;
-  vsg::ref_ptr<KeyboardMap> keyboardMap;
-  SDL_Window *sdlWindow;
-  vsg::ref_ptr<vsg::Viewer> viewer;
+        bool initInstance(std::string title, uint32_t width, uint32_t height,
+                          bool debugLayer, bool apiDumpLayer);
+        bool initSDL();
+        bool initSDLVulkan(std::string dynLib = "") const;
+        bool initSDLVulkanSurface();
+    protected:
+        void pollEvents(const bool continuousKey);
 
-  bool initInstance(std::string title, uint32_t width, uint32_t height,
-                    bool debugLayer, bool apiDumpLayer);
-  bool initSDL();
-  bool initSDLVulkan(std::string dynLib = "") const;
-  bool initSDLVulkanSurface();
+        void pollContinuousLast();
+        void pollContinuous();
 
-protected:
-  void pollEvents(const bool continuousKey);
+        int oldKeyCountSDL;
+        Uint8 *oldKeyStateSDL;
 
-  void pollContinuousLast();
-  void pollContinuous();
+        void keyPressEvent(const SDL_KeyboardEvent *e) const;
+        void keyReleaseEvent(const SDL_KeyboardEvent *e) const;
+        void mouseMoveEvent(const SDL_MouseMotionEvent *e) const;
+        void mousePressEvent(const SDL_MouseButtonEvent *e) const;
+        void mouseReleaseEvent(const SDL_MouseButtonEvent *e) const;
+        void wheelEvent(const SDL_MouseWheelEvent *e) const;
+        void moveEvent(const SDL_WindowEvent *e) const;
+        void resizeEvent(const SDL_WindowEvent *e) const;
 
-  int oldKeyCountSDL;
-  Uint8 *oldKeyStateSDL;
-
-  void keyPressEvent(const SDL_KeyboardEvent *e) const;
-  void keyReleaseEvent(const SDL_KeyboardEvent *e) const;
-  void mouseMoveEvent(const SDL_MouseMotionEvent *e) const;
-  void mousePressEvent(const SDL_MouseButtonEvent *e) const;
-  void mouseReleaseEvent(const SDL_MouseButtonEvent *e) const;
-  void wheelEvent(const SDL_MouseWheelEvent *e) const;
-  void moveEvent(const SDL_WindowEvent *e) const;
-  void resizeEvent(const SDL_WindowEvent *e) const;
-
-  vsg::clock::time_point sdlTimeToVSG(Uint32 timestamp) const;
-};
-} // namespace vsgSDL
+        vsg::clock::time_point sdlTimeToVSG(Uint32 timestamp) const;
+    };
+}
 
 #endif

--- a/include/vsgSDL/window.hpp
+++ b/include/vsgSDL/window.hpp
@@ -1,58 +1,76 @@
-#include <vsgSDL/version.hpp>
+#ifndef VSGSDL_WINDOW_HPP
+#define VSGSDL_WINDOW_HPP
+
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#if TARGET_OS_MAC
+#define VK_USE_PLATFORM_MACOS_MVK
+#elif TARGET_OS_IPHONE
+#define VK_USE_PLATFORM_IOS_MVK
+#endif
+#endif
+
 #include <vsgSDL/keyboard.hpp>
 #include <vsgSDL/mouse.hpp>
+#include <vsgSDL/version.hpp>
 
 namespace vsgSDL {
-    class vsgSDL_LIB Window {
-    public:
-        Window();
-        ~Window();
+class vsgSDL_LIB Window {
+public:
+  Window();
+  ~Window();
 
-        std::function<void(const vsg::ref_ptr<vsg::Window>)> focusGained;
-        std::function<void(const vsg::ref_ptr<vsg::Window>)> focusLost;
-        std::function<void(const char[SDL_TEXTINPUTEVENT_TEXT_SIZE])> textInput;
-        std::function<void(const vsg::ref_ptr<vsg::Viewer>)> render;
-        std::function<void(const vsg::ref_ptr<vsg::Window>,
-                           const vsg::ref_ptr<vsg::Viewer>,
-                           const vsg::ref_ptr<vsg::WindowTraits>)> renderInit;
-        std::function<void(const vsg::ref_ptr<vsg::Viewer>)> renderDeinit;
+  std::function<void(const vsg::ref_ptr<vsg::Window>)> focusGained;
+  std::function<void(const vsg::ref_ptr<vsg::Window>)> focusLost;
+  std::function<void(const char[SDL_TEXTINPUTEVENT_TEXT_SIZE])> textInput;
+  std::function<void(const vsg::ref_ptr<vsg::Viewer>)> render;
+  std::function<void(const vsg::ref_ptr<vsg::Window>,
+                     const vsg::ref_ptr<vsg::Viewer>,
+                     const vsg::ref_ptr<vsg::WindowTraits>)>
+      renderInit;
+  std::function<void(const vsg::ref_ptr<vsg::Viewer>)> renderDeinit;
 
-        bool create(std::string title, int x, int y, uint32_t width, uint32_t height, Uint32 sdlWinFlags,
-                    bool vulkanDebugLayer, bool vulkanAPIDumpLayer, std::string vulkanDynLib = "");
+  bool create(std::string title, int x, int y, uint32_t width, uint32_t height,
+              Uint32 sdlWinFlags, bool vulkanDebugLayer,
+              bool vulkanAPIDumpLayer, std::string vulkanDynLib = "");
 
-        bool process(const bool continuousKey);
-    private:
-        vsg::ref_ptr<vsg::WindowTraits> traits;
-        vsg::ref_ptr<vsg::Instance> instance;
-        vsg::ref_ptr<vsg::Surface> surface;
-        vsg::ref_ptr<vsg::Window> adapter;
-        vsg::ref_ptr<KeyboardMap> keyboardMap;
-        SDL_Window *sdlWindow;
-        vsg::ref_ptr<vsg::Viewer> viewer;
+  bool process(const bool continuousKey);
 
-        bool initInstance(std::string title, uint32_t width, uint32_t height,
-                          bool debugLayer, bool apiDumpLayer);
-        bool initSDL();
-        bool initSDLVulkan(std::string dynLib = "") const;
-        bool initSDLVulkanSurface();
-    protected:
-        void pollEvents(const bool continuousKey);
+private:
+  vsg::ref_ptr<vsg::WindowTraits> traits;
+  vsg::ref_ptr<vsg::Instance> instance;
+  vsg::ref_ptr<vsg::Surface> surface;
+  vsg::ref_ptr<vsg::Window> adapter;
+  vsg::ref_ptr<KeyboardMap> keyboardMap;
+  SDL_Window *sdlWindow;
+  vsg::ref_ptr<vsg::Viewer> viewer;
 
-        void pollContinuousLast();
-        void pollContinuous();
+  bool initInstance(std::string title, uint32_t width, uint32_t height,
+                    bool debugLayer, bool apiDumpLayer);
+  bool initSDL();
+  bool initSDLVulkan(std::string dynLib = "") const;
+  bool initSDLVulkanSurface();
 
-        int oldKeyCountSDL;
-        Uint8 *oldKeyStateSDL;
+protected:
+  void pollEvents(const bool continuousKey);
 
-        void keyPressEvent(const SDL_KeyboardEvent *e) const;
-        void keyReleaseEvent(const SDL_KeyboardEvent *e) const;
-        void mouseMoveEvent(const SDL_MouseMotionEvent *e) const;
-        void mousePressEvent(const SDL_MouseButtonEvent *e) const;
-        void mouseReleaseEvent(const SDL_MouseButtonEvent *e) const;
-        void wheelEvent(const SDL_MouseWheelEvent *e) const;
-        void moveEvent(const SDL_WindowEvent *e) const;
-        void resizeEvent(const SDL_WindowEvent *e) const;
+  void pollContinuousLast();
+  void pollContinuous();
 
-        vsg::clock::time_point sdlTimeToVSG(Uint32 timestamp) const;
-    };
-}
+  int oldKeyCountSDL;
+  Uint8 *oldKeyStateSDL;
+
+  void keyPressEvent(const SDL_KeyboardEvent *e) const;
+  void keyReleaseEvent(const SDL_KeyboardEvent *e) const;
+  void mouseMoveEvent(const SDL_MouseMotionEvent *e) const;
+  void mousePressEvent(const SDL_MouseButtonEvent *e) const;
+  void mouseReleaseEvent(const SDL_MouseButtonEvent *e) const;
+  void wheelEvent(const SDL_MouseWheelEvent *e) const;
+  void moveEvent(const SDL_WindowEvent *e) const;
+  void resizeEvent(const SDL_WindowEvent *e) const;
+
+  vsg::clock::time_point sdlTimeToVSG(Uint32 timestamp) const;
+};
+} // namespace vsgSDL
+
+#endif

--- a/include/vsgSDL/window.hpp
+++ b/include/vsgSDL/window.hpp
@@ -2,19 +2,14 @@
 #define VSGSDL_WINDOW_HPP
 
 #ifdef WIN32
-// min() and max() macros fight against standard c++ pendants
-#define NOMINMAX
-// missing constant
 #define VK_USE_PLATFORM_WIN32_KHR
 #endif
 
 #ifdef __APPLE__
 #include <TargetConditionals.h>
 #if TARGET_OS_MAC
-// missing constant
 #define VK_USE_PLATFORM_MACOS_MVK
 #elif TARGET_OS_IPHONE
-// actually unused, but may come up later
 #define VK_USE_PLATFORM_IOS_MVK
 #endif
 #endif

--- a/include/vsgSDL/window.hpp
+++ b/include/vsgSDL/window.hpp
@@ -1,5 +1,4 @@
-#ifndef VSGSDL_WINDOW_HPP
-#define VSGSDL_WINDOW_HPP
+#pragma once
 
 #include <vsgSDL/version.hpp>
 #include <vsgSDL/keyboard.hpp>
@@ -59,5 +58,3 @@ namespace vsgSDL {
         vsg::clock::time_point sdlTimeToVSG(Uint32 timestamp) const;
     };
 }
-
-#endif

--- a/include/vsgSDL/window.hpp
+++ b/include/vsgSDL/window.hpp
@@ -1,6 +1,10 @@
 #ifndef VSGSDL_WINDOW_HPP
 #define VSGSDL_WINDOW_HPP
 
+#ifdef WIN32
+#define VK_USE_PLATFORM_WIN32_KHR
+#endif
+
 #ifdef __APPLE__
 #include <TargetConditionals.h>
 #if TARGET_OS_MAC

--- a/include/vsgSDL/window.hpp
+++ b/include/vsgSDL/window.hpp
@@ -2,14 +2,19 @@
 #define VSGSDL_WINDOW_HPP
 
 #ifdef WIN32
+// min() and max() macros fight against standard c++ pendants
+#define NOMINMAX
+// missing constant
 #define VK_USE_PLATFORM_WIN32_KHR
 #endif
 
 #ifdef __APPLE__
 #include <TargetConditionals.h>
 #if TARGET_OS_MAC
+// missing constant
 #define VK_USE_PLATFORM_MACOS_MVK
 #elif TARGET_OS_IPHONE
+// actually unused, but may come up later
 #define VK_USE_PLATFORM_IOS_MVK
 #endif
 #endif

--- a/src/vsgSDL/CMakeLists.txt
+++ b/src/vsgSDL/CMakeLists.txt
@@ -19,16 +19,9 @@ set(SOURCES
 )
 
 add_library(vsgSDL ${HEADERS} ${SOURCES})
-#if(MSVC)
-    include (GenerateExportHeader)          
-    GENERATE_EXPORT_HEADER(vsgSDL           # generates the export header shared_EXPORTS.h automatically
-        BASE_NAME vsgSDL
-        EXPORT_MACRO_NAME vsgSDL_EXPORTS
-        EXPORT_FILE_NAME vsgSDL_EXPORTS.h
-        STATIC_DEFINE SHARED_EXPORTS_BUILT_AS_STATIC)
-    set_property(TARGET vsgSDL PROPERTY POSITION_INDEPENDENT_CODE ON)
-    set_property(TARGET vsgSDL PROPERTY CXX_STANDARD 17)
-#endif()
+
+set_property(TARGET vsgSDL PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_property(TARGET vsgSDL PROPERTY CXX_STANDARD 17)
 
 target_include_directories(vsgSDL PUBLIC
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>

--- a/src/vsgSDL/CMakeLists.txt
+++ b/src/vsgSDL/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(NOT CMAKE_DEBUG_POSTFIX)
+  set(CMAKE_DEBUG_POSTFIX d)
+endif()
+
 set(HEADERS
     ${CMAKE_SOURCE_DIR}/include/vsgSDL/export.hpp
     ${CMAKE_SOURCE_DIR}/include/vsgSDL/keyboard.hpp

--- a/src/vsgSDL/CMakeLists.txt
+++ b/src/vsgSDL/CMakeLists.txt
@@ -19,9 +19,16 @@ set(SOURCES
 )
 
 add_library(vsgSDL ${HEADERS} ${SOURCES})
-
-set_property(TARGET vsgSDL PROPERTY POSITION_INDEPENDENT_CODE ON)
-set_property(TARGET vsgSDL PROPERTY CXX_STANDARD 17)
+#if(MSVC)
+    include (GenerateExportHeader)          
+    GENERATE_EXPORT_HEADER(vsgSDL           # generates the export header shared_EXPORTS.h automatically
+        BASE_NAME vsgSDL
+        EXPORT_MACRO_NAME vsgSDL_EXPORTS
+        EXPORT_FILE_NAME vsgSDL_EXPORTS.h
+        STATIC_DEFINE SHARED_EXPORTS_BUILT_AS_STATIC)
+    set_property(TARGET vsgSDL PROPERTY POSITION_INDEPENDENT_CODE ON)
+    set_property(TARGET vsgSDL PROPERTY CXX_STANDARD 17)
+#endif()
 
 target_include_directories(vsgSDL PUBLIC
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>

--- a/src/vsgSDL/window.cpp
+++ b/src/vsgSDL/window.cpp
@@ -9,6 +9,11 @@
 
 #include<vsg/all.h>
 
+#ifdef WIN32
+#undef min
+#undef max
+#endif
+
 namespace vsgSDL {
     static constexpr auto instanceSurfaceName = []() constexpr {
         #if defined(VK_USE_PLATFORM_WIN32_KHR)

--- a/src/vsgSDL/window.cpp
+++ b/src/vsgSDL/window.cpp
@@ -18,8 +18,8 @@
 #include <vsgSDL/window.hpp>
 
 #include <vsg/ui/ScrollWheelEvent.h>
-#include <vsg/viewer/Viewer.h>
-#include <vsg/viewer/WindowAdapter.h>
+#include <vsg/app/Viewer.h>
+#include <vsg/app/WindowAdapter.h>
 
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_vulkan.h>

--- a/src/vsgSDL/window.cpp
+++ b/src/vsgSDL/window.cpp
@@ -1,433 +1,468 @@
+#ifdef WIN32
+// windows header define min()/max() macros. Prevent clashing with vsgSDL c++ source
+#define NOMINMAX
+// define missing constant for Windows
+#define VK_USE_PLATFORM_WIN32_KHR
+#elif __APPLE__
+// looks strange, but it is canonical Apple stuff!
+// define missing constant for the actual Ammple OS
+#include "TargetConditionals.h"
+#ifdef TARGET_OS_OSX
+#define VK_USE_PLATFORM_MACOS_MVK
+#elif TARGET_OS_IPHONE
+// actually unused, may come up later yet
+#define VK_USE_PLATFORM_MACOS_IOS
+#endif
+#endif
+
 #include <vsgSDL/window.hpp>
 
+#include <vsg/ui/ScrollWheelEvent.h>
 #include <vsg/viewer/Viewer.h>
 #include <vsg/viewer/WindowAdapter.h>
-#include <vsg/ui/ScrollWheelEvent.h>
 
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_vulkan.h>
 
-#include<vsg/all.h>
-
-#ifdef WIN32
-#undef min
-#undef max
-#endif
+#include <vsg/all.h>
 
 namespace vsgSDL {
-    static constexpr auto instanceSurfaceName = []() constexpr {
-        #if defined(VK_USE_PLATFORM_WIN32_KHR)
-        return VK_KHR_WIN32_SURFACE_EXTENSION_NAME;
-        #elif defined(VK_USE_PLATFORM_XLIB_KHR)
-        return VK_KHR_XLIB_SURFACE_EXTENSION_NAME;
-        #elif defined(VK_USE_PLATFORM_XCB_KHR)
-        return VK_KHR_XCB_SURFACE_EXTENSION_NAME;
-        #elif defined(VK_USE_PLATFORM_MACOS_MVK)
-        return VK_MVK_MACOS_SURFACE_EXTENSION_NAME;
-        #endif
-    };
-
-
-    Window::Window() {
-        keyboardMap = KeyboardMap::create();
-        traits = vsg::WindowTraits::create();
-    }
-
-    Window::~Window() {
-        renderDeinit(viewer);
-
-        delete [] oldKeyStateSDL;
-
-        SDL_DestroyWindow(sdlWindow);
-        SDL_Quit();
-        SDL_Vulkan_UnloadLibrary();
-    }
-
-    bool Window::process(const bool continuousKey) {
-        pollEvents(continuousKey);
-
-        if(viewer->advanceToNextFrame()) {
-            render(viewer);
-        } else return false;
-
-        if(continuousKey) {
-            pollContinuousLast();
-        }
-
-        return true;
-    }
-
-    bool Window::initInstance(std::string title, uint32_t width, uint32_t height,
-                              bool debugLayer, bool apiDumpLayer) {
-        vsg::Names instanceExtensions;
-        vsg::Names validatedLayers;
-
-        traits = vsg::WindowTraits::create();
-        traits->debugLayer = debugLayer;
-        traits->apiDumpLayer = apiDumpLayer;
-        traits->width = width;
-        traits->height = height;
-        traits->windowTitle = title;
-        traits->windowClass = "vsgSDL";
-
-        instanceExtensions.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
-        instanceExtensions.push_back("VK_KHR_surface");
-        instanceExtensions.push_back(instanceSurfaceName());
-
-        vsg::Names requestedLayers;
-        if(traits->debugLayer || traits->apiDumpLayer) {
-            instanceExtensions.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
-            requestedLayers.push_back("VK_LAYER_KHRONOS_validation");
-
-            if(traits->apiDumpLayer)
-                requestedLayers.push_back("VK_LAYER_LUNARG_api_dump");
-        }
-
-        validatedLayers = vsg::validateInstancelayerNames(requestedLayers);
-        instance = vsg::Instance::create(instanceExtensions, validatedLayers);
-        if(instance == nullptr)
-            return false;
-
-        return true;
-    }
-
-    bool Window::initSDL() {
-        SDL_SetMainReady();
-
-        if(SDL_Init(SDL_INIT_EVERYTHING) != 0)
-            return false;
-
-        SDL_GetKeyboardState(&oldKeyCountSDL);
-        oldKeyStateSDL = new Uint8[oldKeyCountSDL];
-
-        return true;
-    }
-
-    bool Window::initSDLVulkan(std::string dynLib) const {
-        if (dynLib == "")
-            return SDL_Vulkan_LoadLibrary(NULL) != -1;
-        else
-            return SDL_Vulkan_LoadLibrary(dynLib.c_str()) != -1;
-    }
-
-    bool Window::initSDLVulkanSurface() {
-        unsigned int pCount;
-        SDL_Vulkan_GetInstanceExtensions(sdlWindow, &pCount, NULL);
-        const char **pNames = static_cast<const char**>(malloc(sizeof(const char*)*pCount));
-        SDL_Vulkan_GetInstanceExtensions(sdlWindow, &pCount, pNames);
-        vsg::Names instanceExtensionsUnused;
-
-        for(size_t i = 0; i < pCount; i++) {
-            instanceExtensionsUnused.push_back(pNames[i]);
-        }
-
-        SDL_vulkanSurface vulkanSurface;
-        SDL_vulkanInstance vulkanInstance = *instance;
-        if(SDL_Vulkan_CreateSurface(sdlWindow, vulkanInstance, &vulkanSurface) == SDL_FALSE)
-            return false;
-
-        surface = vsg::Surface::create(vulkanSurface, instance);
-        adapter = vsg::WindowAdapter::create(surface, traits);
-        if(auto wa = adapter.cast<vsg::WindowAdapter>(); wa) {
-            wa->windowValid = true;
-            wa->windowVisible = true;
-
-            int dx, dy;
-            SDL_Vulkan_GetDrawableSize(sdlWindow, &dx, &dy);
-            wa->updateExtents(dx, dy);
-
-            int px, py;
-            SDL_GetWindowPosition(sdlWindow, &px, &py);
-
-            vsg::clock::time_point event_time = vsg::clock::now();
-            wa->bufferedEvents.emplace_back(vsg::ConfigureWindowEvent::create(
-                                                wa, event_time, px, py, static_cast<uint32_t>(dx), static_cast<uint32_t>(dy)));
-        } else return false;
-
-        return true;
-    }
-
-    bool Window::create(std::string title, int x, int y, uint32_t width, uint32_t height, Uint32 sdlWinFlags,
-                        bool vulkanDebugLayer, bool vulkanAPIDumpLayer, std::string vulkanDynLib) {
-        if(!initInstance(title, width, height, vulkanDebugLayer, vulkanAPIDumpLayer))
-            return false;
-
-        if(!initSDL())
-            return false;
-
-        if(!initSDLVulkan(vulkanDynLib))
-            return false;
-
-        traits->x = x;
-        traits->y = y;
-        sdlWindow = SDL_CreateWindow(
-                        traits->windowTitle.c_str(), traits->x, traits->y, traits->width, traits->height,
-                        sdlWinFlags);
-        if(sdlWindow == nullptr)
-            return false;
-
-        if(!initSDLVulkanSurface())
-            return false;
-
-        viewer = vsg::Viewer::create();
-        viewer->addWindow(adapter);
-
-        renderInit(adapter, viewer, traits);
-
-        return true;
-    }
-
-    void Window::pollContinuousLast() {
-        const auto lastFrameKeys = SDL_GetKeyboardState(&oldKeyCountSDL);
-        for(auto i = 0; i < oldKeyCountSDL; i++) {
-            oldKeyStateSDL[i] = lastFrameKeys[i];
-        }
-    }
-
-    void Window::pollContinuous() {
-        SDL_PumpEvents();
-
-        int keyCount;
-        auto keyState = SDL_GetKeyboardState(&keyCount);
-
-        for(auto it : keyboardMap->keycodeContinuous) {
-            const auto key = it.first;
-            const bool pressedSLF = (!oldKeyStateSDL[key] && keyState[key]);
-            const bool releasedSLF = (oldKeyStateSDL[key] && !keyState[key]);
-            const bool heldSLF = (oldKeyStateSDL[key] && keyState[key]);
-
-            if(pressedSLF) {
-                vsg::KeySymbol keySymbol = vsg::KEY_Undefined, modifiedKeySymbol = vsg::KEY_Undefined;
-                vsg::KeyModifier keyModifier = vsg::KeyModifier::MODKEY_Control;
-
-                if(keyboardMap->getKeyContinuously(key, keySymbol, modifiedKeySymbol, keyModifier)) {
-                    vsg::clock::time_point event_time = vsg::clock::now();
-                    adapter->bufferedEvents.emplace_back(vsg::KeyPressEvent::create(
-                            adapter, event_time, keySymbol, modifiedKeySymbol, keyModifier));
-                }
-
-            } else if(releasedSLF) {
-                vsg::KeySymbol keySymbol = vsg::KEY_Undefined, modifiedKeySymbol = vsg::KEY_Undefined;
-                vsg::KeyModifier keyModifier = vsg::KeyModifier::MODKEY_Control;
-
-                if(keyboardMap->getKeyContinuously(key, keySymbol, modifiedKeySymbol, keyModifier)) {
-                    vsg::clock::time_point event_time = vsg::clock::now();
-                    adapter->bufferedEvents.emplace_back(vsg::KeyReleaseEvent::create(
-                            adapter, event_time, keySymbol, modifiedKeySymbol, keyModifier));
-                }
-
-            } else if(heldSLF) {
-                ;
-            }
-        }
-    }
-
-    void Window::pollEvents(const bool continuousKey) {
-        if(continuousKey) pollContinuous();
-
-        SDL_Event event;
-        while(SDL_PollEvent(&event) != 0) {
-            switch(event.type) {
-            case SDL_WINDOWEVENT: {
-                switch(event.window.event) {
-                case SDL_WINDOWEVENT_MOVED: {
-                    moveEvent(&event.window);
-                } break;
-
-                case SDL_WINDOWEVENT_RESIZED: {
-                    resizeEvent(&event.window);
-                } break;
-
-                case SDL_WINDOWEVENT_FOCUS_GAINED: {
-                    focusGained(adapter);
-                } break;
-
-                case SDL_WINDOWEVENT_FOCUS_LOST: {
-                    focusLost(adapter);
-                } break;
-
-                case SDL_WINDOWEVENT_CLOSE: {
-                    if(!adapter) return;
-
-                    vsg::clock::time_point eventTime = vsg::clock::now();
-                    adapter->bufferedEvents.emplace_back(vsg::CloseWindowEvent::create(
-                            adapter, eventTime));
-                } break;
-
-                default:
-                    break;
-                }
-            }
-
-            case SDL_TEXTINPUT: {
-                textInput(event.text.text);
-            }
-            break;
-
-            case SDL_KEYDOWN: {
-                if(!continuousKey)
-                    keyPressEvent(&event.key);
-            }
-            break;
-
-            case SDL_KEYUP: {
-                if(!continuousKey)
-                    keyReleaseEvent(&event.key);
-            }
-            break;
-
-            case SDL_MOUSEWHEEL: {
-                switch(event.wheel.type) {
-                case SDL_MOUSEWHEEL:
-                    wheelEvent(&event.wheel);
-                    break;
-                }
-            }
-            break;
-
-            case SDL_MOUSEMOTION: {
-                switch(event.motion.type) {
-                case SDL_MOUSEMOTION: {
-                    mouseMoveEvent(&event.motion);
-                } break;
-                }
-            }
-            break;
-
-            case SDL_MOUSEBUTTONDOWN: {
-                mousePressEvent(&event.button);
-            }
-            break;
-
-            case SDL_MOUSEBUTTONUP: {
-                mouseReleaseEvent(&event.button);
-            }
-            break;
-
-            case SDL_QUIT: {
-                if(!adapter) return;
-
-                vsg::clock::time_point eventTime = vsg::clock::now();
-                adapter->bufferedEvents.emplace_back(vsg::TerminateEvent::create(eventTime));
-            }
-            break;
-
-            default:
-                break;
-            }
-        }
-    }
-
-    void Window::keyPressEvent(const SDL_KeyboardEvent *e) const {
-        if(!adapter) return;
-
-        const auto keyRepeat = e->repeat;
-        vsg::KeySymbol keySymbol = vsg::KEY_Undefined, modifiedKeySymbol = vsg::KEY_Undefined;
-        vsg::KeyModifier keyModifier = vsg::KeyModifier::MODKEY_Control;
-
-        if(keyboardMap->getKeySingularly(e, keySymbol, modifiedKeySymbol, keyModifier)) {
-            vsg::clock::time_point eventTime = vsg::clock::now();
-            adapter->bufferedEvents.emplace_back(vsg::KeyPressEvent::create(
-                    adapter, eventTime, keySymbol, modifiedKeySymbol,
-                    keyModifier, keyRepeat));
-        }
-    }
-
-    void Window::keyReleaseEvent(const SDL_KeyboardEvent *e) const {
-        if(!adapter) return;
-
-        const auto keyRepeat = e->repeat;
-        vsg::KeySymbol keySymbol = vsg::KEY_Undefined, modifiedKeySymbol = vsg::KEY_Undefined;
-        vsg::KeyModifier keyModifier = vsg::KeyModifier::MODKEY_Control;
-
-        if(keyboardMap->getKeySingularly(e, keySymbol, modifiedKeySymbol, keyModifier)) {
-            vsg::clock::time_point eventTime = vsg::clock::now();
-            adapter->bufferedEvents.emplace_back(vsg::KeyReleaseEvent::create(
-                    adapter, eventTime, keySymbol, modifiedKeySymbol,
-                    keyModifier, keyRepeat));
-        }
-    }
-
-    void Window::mouseMoveEvent(const SDL_MouseMotionEvent *e) const {
-        if(!adapter) return;
-
-        int mouseX = e->x;
-        int mouseY = e->y;
-        int buttonState = e->state;
-
-        vsg::clock::time_point eventTime = vsg::clock::now();
-
-        uint16_t mask{0};
-        if(buttonState & SDL_BUTTON(1)) mask |= vsg::BUTTON_MASK_1;
-        if(buttonState & SDL_BUTTON(2)) mask |= vsg::BUTTON_MASK_2;
-        if(buttonState & SDL_BUTTON(3)) mask |= vsg::BUTTON_MASK_3;
-
-        adapter->bufferedEvents.emplace_back(
-            vsg::MoveEvent::create(adapter, eventTime, mouseX, mouseY, vsg::ButtonMask(mask)));
-    }
-
-    void Window::mousePressEvent(const SDL_MouseButtonEvent *e) const {
-        if(!adapter) return;
-
-        int mouseX = e->x;
-        int mouseY = e->y;
-        int mouseState = e->state;
-
-        vsg::clock::time_point eventTime = vsg::clock::now();
-        auto [mask, button] = convertMouseSDL(e->button, mouseState);
-        adapter->bufferedEvents.emplace_back(
-            vsg::ButtonPressEvent::create(adapter, eventTime, mouseX, mouseY, mask, button));
-    }
-
-    void Window::mouseReleaseEvent(const SDL_MouseButtonEvent *e) const {
-        if(!adapter) return;
-
-        int mouseX = e->x;
-        int mouseY = e->y;
-        int mouseState = e->state;
-
-        vsg::clock::time_point eventTime = vsg::clock::now();
-        auto [mask, button] = convertMouseSDL(e->button, mouseState);
-        adapter->bufferedEvents.emplace_back(
-            vsg::ButtonReleaseEvent::create(adapter, eventTime, mouseX, mouseY, mask, button));
-    }
-
-    void Window::wheelEvent(const SDL_MouseWheelEvent *e) const {
-        if(!adapter) return;
-
-        vsg::clock::time_point eventTime = vsg::clock::now();
-        adapter->bufferedEvents.emplace_back(
-            vsg::ScrollWheelEvent::create(adapter, eventTime, e->preciseY < 0 ?
-                                          vsg::vec3(0.0f, -1.0f, 0.0f) : vsg::vec3(0.0f, 1.0f, 0.0f)));
-    }
-
-    void Window::moveEvent(const SDL_WindowEvent *e) const {
-        if(!adapter) return;
-
-        int wx, wy;
-        SDL_GetWindowPosition(sdlWindow, &wx, &wy);
-
-        vsg::clock::time_point eventTime = vsg::clock::now();
-        adapter->bufferedEvents.emplace_back(
-            vsg::ConfigureWindowEvent::create(adapter, eventTime, wx, wy, static_cast<uint32_t>(traits->width),
-                                              static_cast<uint32_t>(traits->height)));
-    }
-
-    void Window::resizeEvent(const SDL_WindowEvent *e) const {
-        if(!adapter) return;
-
-        int px, py, sx, sy;
-        SDL_Vulkan_GetDrawableSize(sdlWindow, &sx, &sy);
-        SDL_GetWindowPosition(sdlWindow, &px, &py);
-
-        vsg::clock::time_point eventTime = vsg::clock::now();
-        adapter->bufferedEvents.emplace_back(vsg::ConfigureWindowEvent::create(
-                adapter, eventTime, px, py, static_cast<uint32_t>(sx), static_cast<uint32_t>(sy)));
-    }
-
-    vsg::clock::time_point Window::sdlTimeToVSG(Uint32 timestamp) const {
-        const std::chrono::milliseconds sdlToChrono(timestamp);
-        const vsg::clock::time_point eventTime(sdlToChrono);
-        return eventTime;
-    }
+static constexpr auto instanceSurfaceName = []() constexpr {
+#if defined(VK_USE_PLATFORM_WIN32_KHR)
+  return VK_KHR_WIN32_SURFACE_EXTENSION_NAME;
+#elif defined(VK_USE_PLATFORM_XLIB_KHR)
+  return VK_KHR_XLIB_SURFACE_EXTENSION_NAME;
+#elif defined(VK_USE_PLATFORM_XCB_KHR)
+  return VK_KHR_XCB_SURFACE_EXTENSION_NAME;
+#elif defined(VK_USE_PLATFORM_MACOS_MVK)
+  return VK_MVK_MACOS_SURFACE_EXTENSION_NAME;
+#endif
+};
+
+Window::Window() {
+  keyboardMap = KeyboardMap::create();
+  traits = vsg::WindowTraits::create();
 }
+
+Window::~Window() {
+  renderDeinit(viewer);
+
+  delete[] oldKeyStateSDL;
+
+  SDL_DestroyWindow(sdlWindow);
+  SDL_Quit();
+  SDL_Vulkan_UnloadLibrary();
+}
+
+bool Window::process(const bool continuousKey) {
+  pollEvents(continuousKey);
+
+  if (viewer->advanceToNextFrame()) {
+    render(viewer);
+  } else
+    return false;
+
+  if (continuousKey) {
+    pollContinuousLast();
+  }
+
+  return true;
+}
+
+bool Window::initInstance(std::string title, uint32_t width, uint32_t height,
+                          bool debugLayer, bool apiDumpLayer) {
+  vsg::Names instanceExtensions;
+  vsg::Names validatedLayers;
+
+  traits = vsg::WindowTraits::create();
+  traits->debugLayer = debugLayer;
+  traits->apiDumpLayer = apiDumpLayer;
+  traits->width = width;
+  traits->height = height;
+  traits->windowTitle = title;
+  traits->windowClass = "vsgSDL";
+
+  instanceExtensions.push_back(
+      VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+  instanceExtensions.push_back("VK_KHR_surface");
+  instanceExtensions.push_back(instanceSurfaceName());
+
+  vsg::Names requestedLayers;
+  if (traits->debugLayer || traits->apiDumpLayer) {
+    instanceExtensions.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
+    requestedLayers.push_back("VK_LAYER_KHRONOS_validation");
+
+    if (traits->apiDumpLayer)
+      requestedLayers.push_back("VK_LAYER_LUNARG_api_dump");
+  }
+
+  validatedLayers = vsg::validateInstancelayerNames(requestedLayers);
+  instance = vsg::Instance::create(instanceExtensions, validatedLayers);
+  if (instance == nullptr)
+    return false;
+
+  return true;
+}
+
+bool Window::initSDL() {
+  SDL_SetMainReady();
+
+  if (SDL_Init(SDL_INIT_EVERYTHING) != 0)
+    return false;
+
+  SDL_GetKeyboardState(&oldKeyCountSDL);
+  oldKeyStateSDL = new Uint8[oldKeyCountSDL];
+
+  return true;
+}
+
+bool Window::initSDLVulkan(std::string dynLib) const {
+  if (dynLib == "")
+    return SDL_Vulkan_LoadLibrary(NULL) != -1;
+  else
+    return SDL_Vulkan_LoadLibrary(dynLib.c_str()) != -1;
+}
+
+bool Window::initSDLVulkanSurface() {
+  unsigned int pCount;
+  SDL_Vulkan_GetInstanceExtensions(sdlWindow, &pCount, NULL);
+  const char **pNames =
+      static_cast<const char **>(malloc(sizeof(const char *) * pCount));
+  SDL_Vulkan_GetInstanceExtensions(sdlWindow, &pCount, pNames);
+  vsg::Names instanceExtensionsUnused;
+
+  for (size_t i = 0; i < pCount; i++) {
+    instanceExtensionsUnused.push_back(pNames[i]);
+  }
+
+  SDL_vulkanSurface vulkanSurface;
+  SDL_vulkanInstance vulkanInstance = *instance;
+  if (SDL_Vulkan_CreateSurface(sdlWindow, vulkanInstance, &vulkanSurface) ==
+      SDL_FALSE)
+    return false;
+
+  surface = vsg::Surface::create(vulkanSurface, instance);
+  adapter = vsg::WindowAdapter::create(surface, traits);
+  if (auto wa = adapter.cast<vsg::WindowAdapter>(); wa) {
+    wa->windowValid = true;
+    wa->windowVisible = true;
+
+    int dx, dy;
+    SDL_Vulkan_GetDrawableSize(sdlWindow, &dx, &dy);
+    wa->updateExtents(dx, dy);
+
+    int px, py;
+    SDL_GetWindowPosition(sdlWindow, &px, &py);
+
+    vsg::clock::time_point event_time = vsg::clock::now();
+    wa->bufferedEvents.emplace_back(vsg::ConfigureWindowEvent::create(
+        wa, event_time, px, py, static_cast<uint32_t>(dx),
+        static_cast<uint32_t>(dy)));
+  } else
+    return false;
+
+  return true;
+}
+
+bool Window::create(std::string title, int x, int y, uint32_t width,
+                    uint32_t height, Uint32 sdlWinFlags, bool vulkanDebugLayer,
+                    bool vulkanAPIDumpLayer, std::string vulkanDynLib) {
+  if (!initInstance(title, width, height, vulkanDebugLayer, vulkanAPIDumpLayer))
+    return false;
+
+  if (!initSDL())
+    return false;
+
+  if (!initSDLVulkan(vulkanDynLib))
+    return false;
+
+  traits->x = x;
+  traits->y = y;
+  sdlWindow =
+      SDL_CreateWindow(traits->windowTitle.c_str(), traits->x, traits->y,
+                       traits->width, traits->height, sdlWinFlags);
+  if (sdlWindow == nullptr)
+    return false;
+
+  if (!initSDLVulkanSurface())
+    return false;
+
+  viewer = vsg::Viewer::create();
+  viewer->addWindow(adapter);
+
+  renderInit(adapter, viewer, traits);
+
+  return true;
+}
+
+void Window::pollContinuousLast() {
+  const auto lastFrameKeys = SDL_GetKeyboardState(&oldKeyCountSDL);
+  for (auto i = 0; i < oldKeyCountSDL; i++) {
+    oldKeyStateSDL[i] = lastFrameKeys[i];
+  }
+}
+
+void Window::pollContinuous() {
+  SDL_PumpEvents();
+
+  int keyCount;
+  auto keyState = SDL_GetKeyboardState(&keyCount);
+
+  for (auto it : keyboardMap->keycodeContinuous) {
+    const auto key = it.first;
+    const bool pressedSLF = (!oldKeyStateSDL[key] && keyState[key]);
+    const bool releasedSLF = (oldKeyStateSDL[key] && !keyState[key]);
+    const bool heldSLF = (oldKeyStateSDL[key] && keyState[key]);
+
+    if (pressedSLF) {
+      vsg::KeySymbol keySymbol = vsg::KEY_Undefined,
+                     modifiedKeySymbol = vsg::KEY_Undefined;
+      vsg::KeyModifier keyModifier = vsg::KeyModifier::MODKEY_Control;
+
+      if (keyboardMap->getKeyContinuously(key, keySymbol, modifiedKeySymbol,
+                                          keyModifier)) {
+        vsg::clock::time_point event_time = vsg::clock::now();
+        adapter->bufferedEvents.emplace_back(vsg::KeyPressEvent::create(
+            adapter, event_time, keySymbol, modifiedKeySymbol, keyModifier));
+      }
+
+    } else if (releasedSLF) {
+      vsg::KeySymbol keySymbol = vsg::KEY_Undefined,
+                     modifiedKeySymbol = vsg::KEY_Undefined;
+      vsg::KeyModifier keyModifier = vsg::KeyModifier::MODKEY_Control;
+
+      if (keyboardMap->getKeyContinuously(key, keySymbol, modifiedKeySymbol,
+                                          keyModifier)) {
+        vsg::clock::time_point event_time = vsg::clock::now();
+        adapter->bufferedEvents.emplace_back(vsg::KeyReleaseEvent::create(
+            adapter, event_time, keySymbol, modifiedKeySymbol, keyModifier));
+      }
+
+    } else if (heldSLF) {
+      ;
+    }
+  }
+}
+
+void Window::pollEvents(const bool continuousKey) {
+  if (continuousKey)
+    pollContinuous();
+
+  SDL_Event event;
+  while (SDL_PollEvent(&event) != 0) {
+    switch (event.type) {
+    case SDL_WINDOWEVENT: {
+      switch (event.window.event) {
+      case SDL_WINDOWEVENT_MOVED: {
+        moveEvent(&event.window);
+      } break;
+
+      case SDL_WINDOWEVENT_RESIZED: {
+        resizeEvent(&event.window);
+      } break;
+
+      case SDL_WINDOWEVENT_FOCUS_GAINED: {
+        focusGained(adapter);
+      } break;
+
+      case SDL_WINDOWEVENT_FOCUS_LOST: {
+        focusLost(adapter);
+      } break;
+
+      case SDL_WINDOWEVENT_CLOSE: {
+        if (!adapter)
+          return;
+
+        vsg::clock::time_point eventTime = vsg::clock::now();
+        adapter->bufferedEvents.emplace_back(
+            vsg::CloseWindowEvent::create(adapter, eventTime));
+      } break;
+
+      default:
+        break;
+      }
+    }
+
+    case SDL_TEXTINPUT: {
+      textInput(event.text.text);
+    } break;
+
+    case SDL_KEYDOWN: {
+      if (!continuousKey)
+        keyPressEvent(&event.key);
+    } break;
+
+    case SDL_KEYUP: {
+      if (!continuousKey)
+        keyReleaseEvent(&event.key);
+    } break;
+
+    case SDL_MOUSEWHEEL: {
+      switch (event.wheel.type) {
+      case SDL_MOUSEWHEEL:
+        wheelEvent(&event.wheel);
+        break;
+      }
+    } break;
+
+    case SDL_MOUSEMOTION: {
+      switch (event.motion.type) {
+      case SDL_MOUSEMOTION: {
+        mouseMoveEvent(&event.motion);
+      } break;
+      }
+    } break;
+
+    case SDL_MOUSEBUTTONDOWN: {
+      mousePressEvent(&event.button);
+    } break;
+
+    case SDL_MOUSEBUTTONUP: {
+      mouseReleaseEvent(&event.button);
+    } break;
+
+    case SDL_QUIT: {
+      if (!adapter)
+        return;
+
+      vsg::clock::time_point eventTime = vsg::clock::now();
+      adapter->bufferedEvents.emplace_back(
+          vsg::TerminateEvent::create(eventTime));
+    } break;
+
+    default:
+      break;
+    }
+  }
+}
+
+void Window::keyPressEvent(const SDL_KeyboardEvent *e) const {
+  if (!adapter)
+    return;
+
+  const auto keyRepeat = e->repeat;
+  vsg::KeySymbol keySymbol = vsg::KEY_Undefined,
+                 modifiedKeySymbol = vsg::KEY_Undefined;
+  vsg::KeyModifier keyModifier = vsg::KeyModifier::MODKEY_Control;
+
+  if (keyboardMap->getKeySingularly(e, keySymbol, modifiedKeySymbol,
+                                    keyModifier)) {
+    vsg::clock::time_point eventTime = vsg::clock::now();
+    adapter->bufferedEvents.emplace_back(
+        vsg::KeyPressEvent::create(adapter, eventTime, keySymbol,
+                                   modifiedKeySymbol, keyModifier, keyRepeat));
+  }
+}
+
+void Window::keyReleaseEvent(const SDL_KeyboardEvent *e) const {
+  if (!adapter)
+    return;
+
+  const auto keyRepeat = e->repeat;
+  vsg::KeySymbol keySymbol = vsg::KEY_Undefined,
+                 modifiedKeySymbol = vsg::KEY_Undefined;
+  vsg::KeyModifier keyModifier = vsg::KeyModifier::MODKEY_Control;
+
+  if (keyboardMap->getKeySingularly(e, keySymbol, modifiedKeySymbol,
+                                    keyModifier)) {
+    vsg::clock::time_point eventTime = vsg::clock::now();
+    adapter->bufferedEvents.emplace_back(vsg::KeyReleaseEvent::create(
+        adapter, eventTime, keySymbol, modifiedKeySymbol, keyModifier,
+        keyRepeat));
+  }
+}
+
+void Window::mouseMoveEvent(const SDL_MouseMotionEvent *e) const {
+  if (!adapter)
+    return;
+
+  int mouseX = e->x;
+  int mouseY = e->y;
+  int buttonState = e->state;
+
+  vsg::clock::time_point eventTime = vsg::clock::now();
+
+  uint16_t mask{0};
+  if (buttonState & SDL_BUTTON(1))
+    mask |= vsg::BUTTON_MASK_1;
+  if (buttonState & SDL_BUTTON(2))
+    mask |= vsg::BUTTON_MASK_2;
+  if (buttonState & SDL_BUTTON(3))
+    mask |= vsg::BUTTON_MASK_3;
+
+  adapter->bufferedEvents.emplace_back(vsg::MoveEvent::create(
+      adapter, eventTime, mouseX, mouseY, vsg::ButtonMask(mask)));
+}
+
+void Window::mousePressEvent(const SDL_MouseButtonEvent *e) const {
+  if (!adapter)
+    return;
+
+  int mouseX = e->x;
+  int mouseY = e->y;
+  int mouseState = e->state;
+
+  vsg::clock::time_point eventTime = vsg::clock::now();
+  auto [mask, button] = convertMouseSDL(e->button, mouseState);
+  adapter->bufferedEvents.emplace_back(vsg::ButtonPressEvent::create(
+      adapter, eventTime, mouseX, mouseY, mask, button));
+}
+
+void Window::mouseReleaseEvent(const SDL_MouseButtonEvent *e) const {
+  if (!adapter)
+    return;
+
+  int mouseX = e->x;
+  int mouseY = e->y;
+  int mouseState = e->state;
+
+  vsg::clock::time_point eventTime = vsg::clock::now();
+  auto [mask, button] = convertMouseSDL(e->button, mouseState);
+  adapter->bufferedEvents.emplace_back(vsg::ButtonReleaseEvent::create(
+      adapter, eventTime, mouseX, mouseY, mask, button));
+}
+
+void Window::wheelEvent(const SDL_MouseWheelEvent *e) const {
+  if (!adapter)
+    return;
+
+  vsg::clock::time_point eventTime = vsg::clock::now();
+  adapter->bufferedEvents.emplace_back(vsg::ScrollWheelEvent::create(
+      adapter, eventTime,
+      e->preciseY < 0 ? vsg::vec3(0.0f, -1.0f, 0.0f)
+                      : vsg::vec3(0.0f, 1.0f, 0.0f)));
+}
+
+void Window::moveEvent(const SDL_WindowEvent *e) const {
+  if (!adapter)
+    return;
+
+  int wx, wy;
+  SDL_GetWindowPosition(sdlWindow, &wx, &wy);
+
+  vsg::clock::time_point eventTime = vsg::clock::now();
+  adapter->bufferedEvents.emplace_back(vsg::ConfigureWindowEvent::create(
+      adapter, eventTime, wx, wy, static_cast<uint32_t>(traits->width),
+      static_cast<uint32_t>(traits->height)));
+}
+
+void Window::resizeEvent(const SDL_WindowEvent *e) const {
+  if (!adapter)
+    return;
+
+  int px, py, sx, sy;
+  SDL_Vulkan_GetDrawableSize(sdlWindow, &sx, &sy);
+  SDL_GetWindowPosition(sdlWindow, &px, &py);
+
+  vsg::clock::time_point eventTime = vsg::clock::now();
+  adapter->bufferedEvents.emplace_back(vsg::ConfigureWindowEvent::create(
+      adapter, eventTime, px, py, static_cast<uint32_t>(sx),
+      static_cast<uint32_t>(sy)));
+}
+
+vsg::clock::time_point Window::sdlTimeToVSG(Uint32 timestamp) const {
+  const std::chrono::milliseconds sdlToChrono(timestamp);
+  const vsg::clock::time_point eventTime(sdlToChrono);
+  return eventTime;
+}
+} // namespace vsgSDL


### PR DESCRIPTION
Applied Header guards.
Option to set shared/static library builds.
Set different names for the library when built in Debug mode. This allows the installation of Release and Debug libraries in the same install prefix.